### PR TITLE
driver-sync: instrument with OpenCensus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ docs/hugo*
 
 # jenv
 .java-version
+
+# data directory
+data/

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,11 @@ configure(subprojects.findAll { it.name != 'util' }) {
         compile 'org.slf4j:slf4j-api:1.7.6', optional
 
         testCompile 'com.google.code.findbugs:jsr305:1.3.9'
+
+        compile 'io.opencensus:opencensus-api:0.14.0'
+        runtime 'io.opencensus:opencensus-impl:0.14.0'
+        compile 'io.opencensus:opencensus-exporter-trace-stackdriver:0.14.0'
+        runtime 'io.opencensus:opencensus-exporter-trace-stackdriver:0.14.0'
     }
 
     /* Compiling */

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -77,6 +77,10 @@ import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -93,6 +97,7 @@ final class Operations<TDocument> {
     private final CodecRegistry codecRegistry;
     private final WriteConcern writeConcern;
     private final boolean retryWrites;
+    private static final Tracer TRACER = Tracing.getTracer();
 
     Operations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
                final CodecRegistry codecRegistry, final WriteConcern writeConcern, final boolean retryWrites) {
@@ -137,40 +142,51 @@ final class Operations<TDocument> {
     @SuppressWarnings("deprecation")
     private <TResult> FindOperation<TResult> createFindOperation(final MongoNamespace findNamespace, final Bson filter,
                                                                  final Class<TResult> resultClass, final FindOptions options) {
-        return new FindOperation<TResult>(findNamespace, codecRegistry.get(resultClass))
-                .filter(filter.toBsonDocument(documentClass, codecRegistry))
-                .batchSize(options.getBatchSize())
-                .skip(options.getSkip())
-                .limit(options.getLimit())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .maxAwaitTime(options.getMaxAwaitTime(MILLISECONDS), MILLISECONDS)
-                .modifiers(toBsonDocumentOrNull(options.getModifiers()))
-                .projection(toBsonDocumentOrNull(options.getProjection()))
-                .sort(toBsonDocumentOrNull(options.getSort()))
-                .cursorType(options.getCursorType())
-                .noCursorTimeout(options.isNoCursorTimeout())
-                .oplogReplay(options.isOplogReplay())
-                .partial(options.isPartial())
-                .slaveOk(readPreference.isSlaveOk())
-                .collation(options.getCollation())
-                .comment(options.getComment())
-                .hint(toBsonDocumentOrNull(options.getHint()))
-                .min(toBsonDocumentOrNull(options.getMin()))
-                .max(toBsonDocumentOrNull(options.getMax()))
-                .maxScan(options.getMaxScan())
-                .returnKey(options.isReturnKey())
-                .showRecordId(options.isShowRecordId())
-                .snapshot(options.isSnapshot());
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.createFindOperation").startScopedSpan();
+
+        try {
+            return new FindOperation<TResult>(findNamespace, codecRegistry.get(resultClass))
+                    .filter(filter.toBsonDocument(documentClass, codecRegistry))
+                    .batchSize(options.getBatchSize())
+                    .skip(options.getSkip())
+                    .limit(options.getLimit())
+                    .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                    .maxAwaitTime(options.getMaxAwaitTime(MILLISECONDS), MILLISECONDS)
+                    .modifiers(toBsonDocumentOrNull(options.getModifiers()))
+                    .projection(toBsonDocumentOrNull(options.getProjection()))
+                    .sort(toBsonDocumentOrNull(options.getSort()))
+                    .cursorType(options.getCursorType())
+                    .noCursorTimeout(options.isNoCursorTimeout())
+                    .oplogReplay(options.isOplogReplay())
+                    .partial(options.isPartial())
+                    .slaveOk(readPreference.isSlaveOk())
+                    .collation(options.getCollation())
+                    .comment(options.getComment())
+                    .hint(toBsonDocumentOrNull(options.getHint()))
+                    .min(toBsonDocumentOrNull(options.getMin()))
+                    .max(toBsonDocumentOrNull(options.getMax()))
+                    .maxScan(options.getMaxScan())
+                    .returnKey(options.isReturnKey())
+                    .showRecordId(options.isShowRecordId())
+                    .snapshot(options.isSnapshot());
+        } finally {
+            ss.close();
+        }
     }
 
     <TResult> DistinctOperation<TResult> distinct(final String fieldName, final Bson filter,
                                                          final Class<TResult> resultClass, final long maxTimeMS,
                                                          final Collation collation) {
-        return new DistinctOperation<TResult>(namespace, fieldName, codecRegistry.get(resultClass))
-                .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
-                .maxTime(maxTimeMS, MILLISECONDS)
-                .collation(collation);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.distinct").startScopedSpan();
 
+        try {
+            return new DistinctOperation<TResult>(namespace, fieldName, codecRegistry.get(resultClass))
+                    .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
+                    .maxTime(maxTimeMS, MILLISECONDS)
+                    .collation(collation);
+        } finally {
+            ss.close();
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -179,28 +195,39 @@ final class Operations<TDocument> {
                                                            final Collation collation,
                                                            final Bson hint, final String comment, final Boolean allowDiskUse,
                                                            final Boolean useCursor) {
-        return new AggregateOperation<TResult>(namespace, toBsonDocumentList(pipeline), codecRegistry.get(resultClass))
-                .maxTime(maxTimeMS, MILLISECONDS)
-                .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
-                .allowDiskUse(allowDiskUse)
-                .batchSize(batchSize)
-                .useCursor(useCursor)
-                .collation(collation)
-                .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
-                .comment(comment);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.aggregate").startScopedSpan();
 
+        try {
+            return new AggregateOperation<TResult>(namespace, toBsonDocumentList(pipeline), codecRegistry.get(resultClass))
+                    .maxTime(maxTimeMS, MILLISECONDS)
+                    .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
+                    .allowDiskUse(allowDiskUse)
+                    .batchSize(batchSize)
+                    .useCursor(useCursor)
+                    .collation(collation)
+                    .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
+                    .comment(comment);
+        } finally {
+            ss.close();
+        }
     }
 
     AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
                                                                 final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
                                                                 final Collation collation, final Bson hint, final String comment) {
-        return new AggregateToCollectionOperation(namespace, toBsonDocumentList(pipeline), writeConcern)
-                .maxTime(maxTimeMS, MILLISECONDS)
-                .allowDiskUse(allowDiskUse)
-                .bypassDocumentValidation(bypassDocumentValidation)
-                .collation(collation)
-                .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
-                .comment(comment);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.aggregateToCollection").startScopedSpan();
+
+        try {
+            return new AggregateToCollectionOperation(namespace, toBsonDocumentList(pipeline), writeConcern)
+                    .maxTime(maxTimeMS, MILLISECONDS)
+                    .allowDiskUse(allowDiskUse)
+                    .bypassDocumentValidation(bypassDocumentValidation)
+                    .collation(collation)
+                    .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
+                    .comment(comment);
+        } finally {
+            ss.close();
+        }
     }
 
     MapReduceToCollectionOperation mapReduceToCollection(final String databaseName, final String collectionName,
@@ -210,26 +237,32 @@ final class Operations<TDocument> {
                                                                 final Bson sort, final boolean verbose, final MapReduceAction action,
                                                                 final boolean nonAtomic, final boolean sharded,
                                                                 final Boolean bypassDocumentValidation, final Collation collation) {
-        MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction),
-                new BsonJavaScript(reduceFunction), collectionName, writeConcern)
-                .filter(toBsonDocumentOrNull(filter))
-                .limit(limit)
-                .maxTime(maxTimeMS, MILLISECONDS)
-                .jsMode(jsMode)
-                .scope(toBsonDocumentOrNull(scope))
-                .sort(toBsonDocumentOrNull(sort))
-                .verbose(verbose)
-                .action(action.getValue())
-                .nonAtomic(nonAtomic)
-                .sharded(sharded)
-                .databaseName(databaseName)
-                .bypassDocumentValidation(bypassDocumentValidation)
-                .collation(collation);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.mapReduceToCollection").startScopedSpan();
 
-        if (finalizeFunction != null) {
-            operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
+        try {
+            MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction),
+                    new BsonJavaScript(reduceFunction), collectionName, writeConcern)
+                    .filter(toBsonDocumentOrNull(filter))
+                    .limit(limit)
+                    .maxTime(maxTimeMS, MILLISECONDS)
+                    .jsMode(jsMode)
+                    .scope(toBsonDocumentOrNull(scope))
+                    .sort(toBsonDocumentOrNull(sort))
+                    .verbose(verbose)
+                    .action(action.getValue())
+                    .nonAtomic(nonAtomic)
+                    .sharded(sharded)
+                    .databaseName(databaseName)
+                    .bypassDocumentValidation(bypassDocumentValidation)
+                    .collation(collation);
+
+            if (finalizeFunction != null) {
+                operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
+            }
+            return operation;
+        } finally {
+            ss.close();
         }
-        return operation;
     }
 
     <TResult> MapReduceWithInlineResultsOperation<TResult> mapReduce(final String mapFunction, final String reduceFunction,
@@ -238,219 +271,322 @@ final class Operations<TDocument> {
                                                                             final long maxTimeMS, final boolean jsMode, final Bson scope,
                                                                             final Bson sort, final boolean verbose,
                                                                             final Collation collation) {
-        MapReduceWithInlineResultsOperation<TResult> operation =
-                new MapReduceWithInlineResultsOperation<TResult>(namespace,
-                        new BsonJavaScript(mapFunction),
-                        new BsonJavaScript(reduceFunction),
-                        codecRegistry.get(resultClass))
-                        .filter(toBsonDocumentOrNull(filter))
-                        .limit(limit)
-                        .maxTime(maxTimeMS, MILLISECONDS)
-                        .jsMode(jsMode)
-                        .scope(toBsonDocumentOrNull(scope))
-                        .sort(toBsonDocumentOrNull(sort))
-                        .verbose(verbose)
-                        .collation(collation);
-        if (finalizeFunction != null) {
-            operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.mapReduce").startScopedSpan();
+
+        try {
+            MapReduceWithInlineResultsOperation<TResult> operation =
+                    new MapReduceWithInlineResultsOperation<TResult>(namespace,
+                            new BsonJavaScript(mapFunction),
+                            new BsonJavaScript(reduceFunction),
+                            codecRegistry.get(resultClass))
+                            .filter(toBsonDocumentOrNull(filter))
+                            .limit(limit)
+                            .maxTime(maxTimeMS, MILLISECONDS)
+                            .jsMode(jsMode)
+                            .scope(toBsonDocumentOrNull(scope))
+                            .sort(toBsonDocumentOrNull(sort))
+                            .verbose(verbose)
+                            .collation(collation);
+            if (finalizeFunction != null) {
+                operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
+            }
+            return operation;
+        } finally {
+            ss.close();
         }
-        return operation;
     }
 
     FindAndDeleteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
-        return new FindAndDeleteOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec())
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .collation(options.getCollation());
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.Operations.findOneAndDelete").startScopedSpan();
+
+        try {
+            return new FindAndDeleteOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec())
+                    .filter(toBsonDocument(filter))
+                    .projection(toBsonDocument(options.getProjection()))
+                    .sort(toBsonDocument(options.getSort()))
+                    .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                    .collation(options.getCollation());
+        } finally {
+            ss.close();
+        }
     }
 
     FindAndReplaceOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
                                                                 final FindOneAndReplaceOptions options) {
-        return new FindAndReplaceOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
-                documentToBsonDocument(replacement))
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation());
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.findOneAndReplace").startScopedSpan();
+
+        try {
+            return new FindAndReplaceOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
+                    documentToBsonDocument(replacement))
+                    .filter(toBsonDocument(filter))
+                    .projection(toBsonDocument(options.getProjection()))
+                    .sort(toBsonDocument(options.getSort()))
+                    .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
+                    .upsert(options.isUpsert())
+                    .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                    .bypassDocumentValidation(options.getBypassDocumentValidation())
+                    .collation(options.getCollation());
+        } finally {
+            ss.close();
+        }
     }
 
     FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
-        return new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
-                toBsonDocument(update))
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation())
-                .arrayFilters(toBsonDocumentList(options.getArrayFilters()));
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.findOneAndUpdate").startScopedSpan();
+
+        try {
+            return new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
+                    toBsonDocument(update))
+                    .filter(toBsonDocument(filter))
+                    .projection(toBsonDocument(options.getProjection()))
+                    .sort(toBsonDocument(options.getSort()))
+                    .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
+                    .upsert(options.isUpsert())
+                    .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                    .bypassDocumentValidation(options.getBypassDocumentValidation())
+                    .collation(options.getCollation())
+                    .arrayFilters(toBsonDocumentList(options.getArrayFilters()));
+        } finally {
+            ss.close();
+        }
     }
 
 
     MixedBulkWriteOperation insertOne(final TDocument document, final InsertOneOptions options) {
-        return bulkWrite(singletonList(new InsertOneModel<TDocument>(document)),
-                new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.insertOne").startScopedSpan();
+
+        try {
+            return bulkWrite(singletonList(new InsertOneModel<TDocument>(document)),
+                    new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
+        } finally {
+            ss.close();
+        }
     }
 
 
     MixedBulkWriteOperation replaceOne(final Bson filter, final TDocument replacement, final ReplaceOptions options) {
-        return bulkWrite(singletonList(new ReplaceOneModel<TDocument>(filter, replacement, options)),
-                new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.replaceOne").startScopedSpan();
+
+        try {
+            return bulkWrite(singletonList(new ReplaceOneModel<TDocument>(filter, replacement, options)),
+                    new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
+        } finally {
+            ss.close();
+        }
     }
 
     MixedBulkWriteOperation deleteOne(final Bson filter, final DeleteOptions options) {
-        return bulkWrite(singletonList(new DeleteOneModel<TDocument>(filter, options)), new BulkWriteOptions());
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.deleteOne").startScopedSpan();
+
+        try {
+            return bulkWrite(singletonList(new DeleteOneModel<TDocument>(filter, options)), new BulkWriteOptions());
+        } finally {
+            ss.close();
+        }
     }
 
     MixedBulkWriteOperation deleteMany(final Bson filter, final DeleteOptions options) {
-        return bulkWrite(singletonList(new DeleteManyModel<TDocument>(filter, options)), new BulkWriteOptions());
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.deleteMany").startScopedSpan();
+
+        try {
+            return bulkWrite(singletonList(new DeleteManyModel<TDocument>(filter, options)), new BulkWriteOptions());
+        } finally {
+            ss.close();
+        }
     }
 
     MixedBulkWriteOperation updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return bulkWrite(singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
-                new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.updateOne").startScopedSpan();
+
+        try {
+            return bulkWrite(singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
+                    new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
+        } finally {
+            ss.close();
+        }
     }
 
     MixedBulkWriteOperation updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return bulkWrite(singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
-                new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.updateMany").startScopedSpan();
+
+        try {
+            return bulkWrite(singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
+                    new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
+        } finally {
+            ss.close();
+        }
     }
 
     MixedBulkWriteOperation insertMany(final List<? extends TDocument> documents,
                                               final InsertManyOptions options) {
-        notNull("documents", documents);
-        List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
-        for (TDocument document : documents) {
-            if (document == null) {
-                throw new IllegalArgumentException("documents can not contain a null value");
-            }
-            if (getCodec() instanceof CollectibleCodec) {
-                document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-            }
-            requests.add(new InsertRequest(documentToBsonDocument(document)));
-        }
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.insertMany").startScopedSpan();
 
-        return new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern, retryWrites)
-                .bypassDocumentValidation(options.getBypassDocumentValidation());
+        try {
+            notNull("documents", documents);
+            List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
+            for (TDocument document : documents) {
+                if (document == null) {
+                    throw new IllegalArgumentException("documents can not contain a null value");
+                }
+                if (getCodec() instanceof CollectibleCodec) {
+                    document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
+                }
+                requests.add(new InsertRequest(documentToBsonDocument(document)));
+            }
+
+            return new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern, retryWrites)
+                    .bypassDocumentValidation(options.getBypassDocumentValidation());
+        } finally {
+            ss.close();
+        }
     }
 
     @SuppressWarnings("unchecked")
     MixedBulkWriteOperation bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
                                              final BulkWriteOptions options) {
-        notNull("requests", requests);
-        List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
-        for (WriteModel<? extends TDocument> writeModel : requests) {
-            WriteRequest writeRequest;
-            if (writeModel == null) {
-                throw new IllegalArgumentException("requests can not contain a null value");
-            } else if (writeModel instanceof InsertOneModel) {
-                TDocument document = ((InsertOneModel<TDocument>) writeModel).getDocument();
-                if (getCodec() instanceof CollectibleCodec) {
-                    document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-                }
-                writeRequest = new InsertRequest(documentToBsonDocument(document));
-            } else if (writeModel instanceof ReplaceOneModel) {
-                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
-                        .getReplacement()),
-                        WriteRequest.Type.REPLACE)
-                        .upsert(replaceOneModel.getReplaceOptions().isUpsert())
-                        .collation(replaceOneModel.getReplaceOptions().getCollation());
-            } else if (writeModel instanceof UpdateOneModel) {
-                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
-                        WriteRequest.Type.UPDATE)
-                        .multi(false)
-                        .upsert(updateOneModel.getOptions().isUpsert())
-                        .collation(updateOneModel.getOptions().getCollation())
-                        .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()));
-            } else if (writeModel instanceof UpdateManyModel) {
-                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
-                        WriteRequest.Type.UPDATE)
-                        .multi(true)
-                        .upsert(updateManyModel.getOptions().isUpsert())
-                        .collation(updateManyModel.getOptions().getCollation())
-                        .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()));
-            } else if (writeModel instanceof DeleteOneModel) {
-                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
-                writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)
-                        .collation(deleteOneModel.getOptions().getCollation());
-            } else if (writeModel instanceof DeleteManyModel) {
-                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
-                writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true)
-                        .collation(deleteManyModel.getOptions().getCollation());
-            } else {
-                throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
-            }
-            writeRequests.add(writeRequest);
-        }
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropCollection").startScopedSpan();
 
-        return new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(), writeConcern, retryWrites)
-                .bypassDocumentValidation(options.getBypassDocumentValidation());
+        try {
+            notNull("requests", requests);
+            List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
+            for (WriteModel<? extends TDocument> writeModel : requests) {
+                WriteRequest writeRequest;
+                if (writeModel == null) {
+                    throw new IllegalArgumentException("requests can not contain a null value");
+                } else if (writeModel instanceof InsertOneModel) {
+                    TDocument document = ((InsertOneModel<TDocument>) writeModel).getDocument();
+                    if (getCodec() instanceof CollectibleCodec) {
+                        document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
+                    }
+                    writeRequest = new InsertRequest(documentToBsonDocument(document));
+                } else if (writeModel instanceof ReplaceOneModel) {
+                    ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
+                    writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
+                            .getReplacement()),
+                            WriteRequest.Type.REPLACE)
+                            .upsert(replaceOneModel.getReplaceOptions().isUpsert())
+                            .collation(replaceOneModel.getReplaceOptions().getCollation());
+                } else if (writeModel instanceof UpdateOneModel) {
+                    UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
+                    writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
+                            WriteRequest.Type.UPDATE)
+                            .multi(false)
+                            .upsert(updateOneModel.getOptions().isUpsert())
+                            .collation(updateOneModel.getOptions().getCollation())
+                            .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()));
+                } else if (writeModel instanceof UpdateManyModel) {
+                    UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
+                    writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()),
+                            toBsonDocument(updateManyModel.getUpdate()),
+                            WriteRequest.Type.UPDATE)
+                            .multi(true)
+                            .upsert(updateManyModel.getOptions().isUpsert())
+                            .collation(updateManyModel.getOptions().getCollation())
+                            .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()));
+                } else if (writeModel instanceof DeleteOneModel) {
+                    DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
+                    writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)
+                            .collation(deleteOneModel.getOptions().getCollation());
+                } else if (writeModel instanceof DeleteManyModel) {
+                    DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
+                    writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true)
+                            .collation(deleteManyModel.getOptions().getCollation());
+                } else {
+                    throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
+                }
+                writeRequests.add(writeRequest);
+            }
+
+            return new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(), writeConcern, retryWrites)
+                    .bypassDocumentValidation(options.getBypassDocumentValidation());
+        } finally {
+            ss.close();
+        }
     }
 
 
     DropCollectionOperation dropCollection() {
-        return new DropCollectionOperation(namespace, writeConcern);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropCollection").startScopedSpan();
+
+        try {
+            return new DropCollectionOperation(namespace, writeConcern);
+        } finally {
+            ss.close();
+        }
     }
 
 
     RenameCollectionOperation renameCollection(final MongoNamespace newCollectionNamespace,
                                                       final RenameCollectionOptions renameCollectionOptions) {
-        return new RenameCollectionOperation(namespace, newCollectionNamespace, writeConcern)
-                .dropTarget(renameCollectionOptions.isDropTarget());
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.renameCollection").startScopedSpan();
+
+        try {
+            return new RenameCollectionOperation(namespace, newCollectionNamespace, writeConcern)
+                    .dropTarget(renameCollectionOptions.isDropTarget());
+        } finally {
+            ss.close();
+        }
     }
 
     CreateIndexesOperation createIndexes(final List<IndexModel> indexes, final CreateIndexOptions createIndexOptions) {
-        notNull("indexes", indexes);
-        notNull("createIndexOptions", createIndexOptions);
-        List<IndexRequest> indexRequests = new ArrayList<IndexRequest>(indexes.size());
-        for (IndexModel model : indexes) {
-            if (model == null) {
-                throw new IllegalArgumentException("indexes can not contain a null value");
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.createIndexes").startScopedSpan();
+
+        try {
+            notNull("indexes", indexes);
+            notNull("createIndexOptions", createIndexOptions);
+            List<IndexRequest> indexRequests = new ArrayList<IndexRequest>(indexes.size());
+            for (IndexModel model : indexes) {
+                if (model == null) {
+                    throw new IllegalArgumentException("indexes can not contain a null value");
+                }
+                indexRequests.add(new IndexRequest(toBsonDocument(model.getKeys()))
+                        .name(model.getOptions().getName())
+                        .background(model.getOptions().isBackground())
+                        .unique(model.getOptions().isUnique())
+                        .sparse(model.getOptions().isSparse())
+                        .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
+                        .version(model.getOptions().getVersion())
+                        .weights(toBsonDocument(model.getOptions().getWeights()))
+                        .defaultLanguage(model.getOptions().getDefaultLanguage())
+                        .languageOverride(model.getOptions().getLanguageOverride())
+                        .textVersion(model.getOptions().getTextVersion())
+                        .sphereVersion(model.getOptions().getSphereVersion())
+                        .bits(model.getOptions().getBits())
+                        .min(model.getOptions().getMin())
+                        .max(model.getOptions().getMax())
+                        .bucketSize(model.getOptions().getBucketSize())
+                        .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
+                        .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
+                        .collation(model.getOptions().getCollation())
+                );
             }
-            indexRequests.add(new IndexRequest(toBsonDocument(model.getKeys()))
-                    .name(model.getOptions().getName())
-                    .background(model.getOptions().isBackground())
-                    .unique(model.getOptions().isUnique())
-                    .sparse(model.getOptions().isSparse())
-                    .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
-                    .version(model.getOptions().getVersion())
-                    .weights(toBsonDocument(model.getOptions().getWeights()))
-                    .defaultLanguage(model.getOptions().getDefaultLanguage())
-                    .languageOverride(model.getOptions().getLanguageOverride())
-                    .textVersion(model.getOptions().getTextVersion())
-                    .sphereVersion(model.getOptions().getSphereVersion())
-                    .bits(model.getOptions().getBits())
-                    .min(model.getOptions().getMin())
-                    .max(model.getOptions().getMax())
-                    .bucketSize(model.getOptions().getBucketSize())
-                    .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
-                    .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
-                    .collation(model.getOptions().getCollation())
-            );
+            return new CreateIndexesOperation(namespace, indexRequests, writeConcern)
+                    .maxTime(createIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        } finally {
+            ss.close();
         }
-        return new CreateIndexesOperation(namespace, indexRequests, writeConcern)
-                .maxTime(createIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
     }
 
     DropIndexOperation dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
-        return new DropIndexOperation(namespace, indexName, writeConcern)
-                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropIndex").startScopedSpan();
+
+        try {
+            return new DropIndexOperation(namespace, indexName, writeConcern)
+                    .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        } finally {
+            ss.close();
+        }
     }
 
     DropIndexOperation dropIndex(final Bson keys, final DropIndexOptions dropIndexOptions) {
-        return new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
-                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropIndex").startScopedSpan();
+
+        try {
+            return new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
+                    .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        } finally {
+            ss.close();
+        }
     }
 
     <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -47,6 +47,11 @@ import com.mongodb.operation.WriteOperation;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+
+
 import java.util.List;
 
 /**
@@ -54,6 +59,7 @@ import java.util.List;
  */
 public final class SyncOperations<TDocument> {
     private final Operations<TDocument> operations;
+    private static final Tracer TRACER = Tracing.getTracer();
 
     public SyncOperations(final Class<TDocument> documentClass, final ReadPreference readPreference,
                           final CodecRegistry codecRegistry) {
@@ -71,42 +77,84 @@ public final class SyncOperations<TDocument> {
     }
 
     public ReadOperation<Long> count(final Bson filter, final CountOptions options, final CountStrategy countStrategy) {
-        return operations.count(filter, options, countStrategy);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.count").startScopedSpan();
+
+        try {
+            return operations.count(filter, options, countStrategy);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> findFirst(final Bson filter, final Class<TResult> resultClass,
                                                                    final FindOptions options) {
-        return operations.findFirst(filter, resultClass, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.findFirst").startScopedSpan();
+
+        try {
+            return operations.findFirst(filter, resultClass, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> find(final Bson filter, final Class<TResult> resultClass,
                                                               final FindOptions options) {
-        return operations.find(filter, resultClass, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.find").startScopedSpan();
+
+        try {
+            return operations.find(filter, resultClass, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> find(final MongoNamespace findNamespace, final Bson filter,
                                                               final Class<TResult> resultClass, final FindOptions options) {
-        return operations.find(findNamespace, filter, resultClass, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.find").startScopedSpan();
+
+        try {
+            return operations.find(findNamespace, filter, resultClass, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
                                                                   final Class<TResult> resultClass, final long maxTimeMS,
                                                                   final Collation collation) {
-        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.distinct").startScopedSpan();
+
+        try {
+            return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
                                                                    final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
                                                                    final Collation collation, final Bson hint, final String comment,
                                                                    final Boolean allowDiskUse, final Boolean useCursor) {
-        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
-                useCursor);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.aggregate").startScopedSpan();
+
+        try {
+            return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
+                    useCursor);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
                                                       final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
                                                       final Collation collation, final Bson hint, final String comment) {
-        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.aggregateToCollection").startScopedSpan();
+
+        try {
+            return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
@@ -116,8 +164,14 @@ public final class SyncOperations<TDocument> {
                                                                      final Bson sort, final boolean verbose, final MapReduceAction action,
                                                                      final boolean nonAtomic, final boolean sharded,
                                                                      final Boolean bypassDocumentValidation, final Collation collation) {
-        return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,
-                maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.mapReduceToCollection").startScopedSpan();
+
+        try {
+            return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter,
+                    limit, maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<MapReduceBatchCursor<TResult>> mapReduce(final String mapFunction, final String reduceFunction,
@@ -126,94 +180,214 @@ public final class SyncOperations<TDocument> {
                                                                             final long maxTimeMS, final boolean jsMode, final Bson scope,
                                                                             final Bson sort, final boolean verbose,
                                                                             final Collation collation) {
-        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
-                sort, verbose, collation);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.mapReduce").startScopedSpan();
+
+        try {
+            return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
+                    sort, verbose, collation);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
-        return operations.findOneAndDelete(filter, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.findOneAndDelete").startScopedSpan();
+
+        try {
+            return operations.findOneAndDelete(filter, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
                                                        final FindOneAndReplaceOptions options) {
-        return operations.findOneAndReplace(filter, replacement, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.findOneAndReplace").startScopedSpan();
+
+        try {
+            return operations.findOneAndReplace(filter, replacement, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
-        return operations.findOneAndUpdate(filter, update, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.findOneAndUpdate").startScopedSpan();
+
+        try {
+            return operations.findOneAndUpdate(filter, update, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<BulkWriteResult> insertOne(final TDocument document, final InsertOneOptions options) {
-        return operations.insertOne(document, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.insertOne").startScopedSpan();
+
+        try {
+            return operations.insertOne(document, options);
+        } finally {
+            ss.close();
+        }
     }
 
 
     public WriteOperation<BulkWriteResult> replaceOne(final Bson filter, final TDocument replacement, final ReplaceOptions options) {
-        return operations.replaceOne(filter, replacement, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.replaceOne").startScopedSpan();
+
+        try {
+            return operations.replaceOne(filter, replacement, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<BulkWriteResult> deleteOne(final Bson filter, final DeleteOptions options) {
-        return operations.deleteOne(filter, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.deleteOne").startScopedSpan();
+
+        try {
+            return operations.deleteOne(filter, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<BulkWriteResult> deleteMany(final Bson filter, final DeleteOptions options) {
-        return operations.deleteMany(filter, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.deleteMany").startScopedSpan();
+
+        try {
+            return operations.deleteMany(filter, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<BulkWriteResult> updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return operations.updateOne(filter, update, updateOptions);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.updateOne").startScopedSpan();
+
+        try {
+            return operations.updateOne(filter, update, updateOptions);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<BulkWriteResult> updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return operations.updateMany(filter, update, updateOptions);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.updateMany").startScopedSpan();
+
+        try {
+            return operations.updateMany(filter, update, updateOptions);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<BulkWriteResult> insertMany(final List<? extends TDocument> documents,
                                                       final InsertManyOptions options) {
-        return operations.insertMany(documents, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.insertMany").startScopedSpan();
+
+        try {
+            return operations.insertMany(documents, options);
+        } finally {
+            ss.close();
+        }
     }
 
     @SuppressWarnings("unchecked")
     public WriteOperation<BulkWriteResult> bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
                                                      final BulkWriteOptions options) {
-        return operations.bulkWrite(requests, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.bulkWrite").startScopedSpan();
+
+        try {
+            return operations.bulkWrite(requests, options);
+        } finally {
+            ss.close();
+        }
     }
 
 
     public WriteOperation<Void> dropCollection() {
-        return operations.dropCollection();
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropCollection").startScopedSpan();
+
+        try {
+            return operations.dropCollection();
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<Void> renameCollection(final MongoNamespace newCollectionNamespace,
                                                  final RenameCollectionOptions options) {
-        return operations.renameCollection(newCollectionNamespace, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.renameCollection").startScopedSpan();
+
+        try {
+            return operations.renameCollection(newCollectionNamespace, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions options) {
-        return operations.createIndexes(indexes, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.createIndexes").startScopedSpan();
+
+        try {
+            return operations.createIndexes(indexes, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {
-        return operations.dropIndex(indexName, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropIndex").startScopedSpan();
+
+        try {
+            return operations.dropIndex(indexName, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public WriteOperation<Void> dropIndex(final Bson keys, final DropIndexOptions options) {
-        return operations.dropIndex(keys, options);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.dropIndex").startScopedSpan();
+
+        try {
+            return operations.dropIndex(keys, options);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listCollections(final String databaseName, final Class<TResult> resultClass,
                                                                          final Bson filter, final boolean collectionNamesOnly,
                                                                          final Integer batchSize, final long maxTimeMS) {
-        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, batchSize, maxTimeMS);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.listCollections").startScopedSpan();
+
+        try {
+            return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, batchSize, maxTimeMS);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,
                                                                        final Boolean nameOnly, final long maxTimeMS) {
-        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.listDatabases").startScopedSpan();
+
+        try {
+            return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS);
+        } finally {
+            ss.close();
+        }
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
                                                                      final long maxTimeMS) {
-        return operations.listIndexes(resultClass, batchSize, maxTimeMS);
+        Scope ss = TRACER.spanBuilder("com.mongodb.internal.operation.SyncOperations.listIndexes").startScopedSpan();
+
+        try {
+            return operations.listIndexes(resultClass, batchSize, maxTimeMS);
+        } finally {
+            ss.close();
+        }
     }
 }

--- a/driver-sync/src/examples/tour/QuickTour.java
+++ b/driver-sync/src/examples/tour/QuickTour.java
@@ -32,6 +32,12 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceConfiguration;
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter;
+import io.opencensus.trace.samplers.Samplers;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.Tracing;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,6 +69,19 @@ public class QuickTour {
      * @param args takes an optional single argument for the connection string
      */
     public static void main(final String[] args) {
+        try {
+            StackdriverTraceExporter.createAndRegister(
+                StackdriverTraceConfiguration.builder()
+                .setProjectId("census-demos")
+                .build());
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+
+        TraceConfig traceConfig = Tracing.getTraceConfig();
+        traceConfig.updateActiveTraceParams(
+            traceConfig.getActiveTraceParams().toBuilder().setSampler(Samplers.alwaysSample()).build());
+
         MongoClient mongoClient;
 
         if (args.length == 0) {

--- a/driver-sync/src/main/com/mongodb/client/MongoClients.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClients.java
@@ -22,6 +22,9 @@ import com.mongodb.MongoDriverInformation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.client.internal.MongoClientImpl;
 
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
 
 /**
  * A factory for {@link MongoClient} instances.  Use of this class is now the recommended way to connect to MongoDB via the Java driver.
@@ -30,6 +33,8 @@ import com.mongodb.client.internal.MongoClientImpl;
  * @since 3.7
  */
 public final class MongoClients {
+
+    private static final Tracer TRACER = Tracing.getTracer();
 
     /**
      * Creates a new client with the default connection string "mongodb://localhost".
@@ -109,7 +114,13 @@ public final class MongoClients {
      * @return the client
      */
     public static MongoClient create(final MongoClientSettings settings, @Nullable final MongoDriverInformation mongoDriverInformation) {
-        return new MongoClientImpl(settings, mongoDriverInformation);
+        Scope ss = TRACER.spanBuilder("com.mongodb.client.MongoClients.create").startScopedSpan();
+
+        try {
+            return new MongoClientImpl(settings, mongoDriverInformation);
+        } finally {
+            ss.close();
+        }
     }
 
     private MongoClients() {

--- a/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
@@ -33,6 +33,10 @@ import com.mongodb.operation.MapReduceStatistics;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.operation.WriteOperation;
 import com.mongodb.client.ClientSession;
+
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracing;
+
 import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -216,9 +220,15 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     }
 
     private WriteOperation<MapReduceStatistics> createMapReduceToCollectionOperation() {
-        return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter,
-                limit, maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation
-        );
+        Scope ss = Tracing.getTracer().spanBuilder("com.mongodb.client.internal.MapReduceIterableImpl.WriteOperation").startScopedSpan();
+
+        try {
+            return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter,
+                    limit, maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation
+            );
+        } finally {
+            ss.close();
+        }
     }
 
     // this could be inlined, but giving it a name so that it's unit-testable

--- a/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
@@ -32,6 +32,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceConfiguration;
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.samplers.Samplers;
+import io.opencensus.trace.Tracing;
+
 import static com.mongodb.ClusterFixture.serverVersionGreaterThan;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static org.junit.Assert.assertEquals;
@@ -51,6 +57,18 @@ public class CrudTest extends DatabaseTestCase {
         this.description = description;
         this.data = data;
         this.definition = definition;
+
+        try {
+                StackdriverTraceExporter.createAndRegister(
+                                StackdriverTraceConfiguration.builder()
+                                .setProjectId("census-demos")
+                                .build());
+        } catch (Exception e) {
+        } finally {
+                TraceConfig traceConfig = Tracing.getTraceConfig();
+                traceConfig.updateActiveTraceParams(
+                                traceConfig.getActiveTraceParams().toBuilder().setSampler(Samplers.alwaysSample()).build());
+        }
     }
 
     @Before


### PR DESCRIPTION
Work in progress to instrument this driver with OpenCensus.
All tests pass, repro coming up soon too.

driver-sync/com.mongodb.client.internal: ScopedSpans

Use ScopedSpans to enable proper context propagation
instead of starting and ending spans manually.

Thanks to @bogdandrutu for the advice.